### PR TITLE
Add resolutions for `snaps` packages with `cip3` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
     "master-sync": "node development/master-sync.js"
   },
   "resolutions": {
+    "@metamask/snaps-rpc-methods": "https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-rpc-methods-7.0.1-cip3.tgz",
+    "@metamask/snaps-sdk": "https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-sdk-3.1.0-cip3.tgz",
+    "@metamask/snaps-utils": "https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-utils-7.0.2-cip3.tgz",
+    "@metamask/key-tree": "https://github.com/nufi-official/metamask-key-tree/releases/download/v10.0.0-cip3/metamask-key-tree-10.0.0-cip3.tgz",
     "simple-update-notifier@^1.0.0": "^2.0.0",
     "@babel/core": "patch:@babel/core@npm%3A7.23.2#~/.yarn/patches/@babel-core-npm-7.23.2-b93f586907.patch",
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.23.2#~/.yarn/patches/@babel-runtime-npm-7.23.2-d013d6cf7e.patch",
@@ -214,8 +218,7 @@
     "semver@7.3.8": "^7.5.4",
     "nonce-tracker@npm:^3.0.0": "patch:nonce-tracker@npm%3A3.0.0#~/.yarn/patches/nonce-tracker-npm-3.0.0-c5e9a93f9d.patch",
     "@trezor/connect-web": "9.0.11",
-    "lavamoat-core@npm:^15.1.1": "patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch",
-    "@metamask/snaps-sdk": "^3.1.0"
+    "lavamoat-core@npm:^15.1.1": "patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4574,17 +4574,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/key-tree@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@metamask/key-tree@npm:9.0.0"
+"@metamask/key-tree@https://github.com/nufi-official/metamask-key-tree/releases/download/v10.0.0-cip3/metamask-key-tree-10.0.0-cip3.tgz":
+  version: 10.0.0-cip3
+  resolution: "@metamask/key-tree@https://github.com/nufi-official/metamask-key-tree/releases/download/v10.0.0-cip3/metamask-key-tree-10.0.0-cip3.tgz"
   dependencies:
-    "@metamask/scure-bip39": "npm:^2.1.0"
-    "@metamask/utils": "npm:^6.0.1"
-    "@noble/ed25519": "npm:^1.6.0"
-    "@noble/hashes": "npm:^1.0.0"
-    "@noble/secp256k1": "npm:^1.5.5"
+    "@metamask/scure-bip39": "npm:^2.1.1"
+    "@metamask/utils": "npm:^8.3.0"
+    "@noble/curves": "npm:^1.2.0"
+    "@noble/hashes": "npm:^1.3.2"
     "@scure/base": "npm:^1.0.0"
-  checksum: 089ddb2ed44b70e3112f8466b0679159c9a23ed6269357ba5693bbdc3dae050173b5044a482fad381297b2a0899a65ccba763cdec0a19a61d626119b55d64fc8
+  checksum: 930bc68eddae6efc2f5de206eab8393cd1a16fa4fe1f504be216a1f52c88f46a88d15082ebe7e11c746d87508cd3dabf8a7cf8de6c78ed8ad1723a16fd1ffded
   languageName: node
   linkType: hard
 
@@ -5068,6 +5067,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/scure-bip39@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@metamask/scure-bip39@npm:2.1.1"
+  dependencies:
+    "@noble/hashes": "npm:~1.3.2"
+    "@scure/base": "npm:~1.1.3"
+  checksum: 785d75e52f85103af7556c25d3dbba6da52ee9e61c31e95786bfbab0e18b9899a367bf714c71dd311c04161c45ba14354bd6fb4fbeb42cb26b7bd2f35c582f73
+  languageName: node
+  linkType: hard
+
 "@metamask/selected-network-controller@npm:^9.0.0":
   version: 9.0.0
   resolution: "@metamask/selected-network-controller@npm:9.0.0"
@@ -5270,57 +5279,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@metamask/snaps-rpc-methods@npm:4.1.0"
-  dependencies:
-    "@metamask/key-tree": "npm:^9.0.0"
-    "@metamask/permission-controller": "npm:^7.0.0"
-    "@metamask/rpc-errors": "npm:^6.1.0"
-    "@metamask/snaps-sdk": "npm:^1.3.1"
-    "@metamask/snaps-utils": "npm:^5.1.1"
-    "@metamask/utils": "npm:^8.2.1"
-    "@noble/hashes": "npm:^1.3.1"
-    superstruct: "npm:^1.0.3"
-  checksum: 1e3f0bcb407b1bf53ed045a1914ee70f4e692c4d8cb453bf0d9e9ff7519a24adb695181d2eb336e010e908f7e4198e76b498dc3510e3271a75c2c5a3db98068f
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-rpc-methods@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@metamask/snaps-rpc-methods@npm:5.0.0"
-  dependencies:
-    "@metamask/key-tree": "npm:^9.0.0"
-    "@metamask/permission-controller": "npm:^7.1.0"
-    "@metamask/rpc-errors": "npm:^6.1.0"
-    "@metamask/snaps-sdk": "npm:^1.4.0"
-    "@metamask/snaps-utils": "npm:^5.2.0"
-    "@metamask/utils": "npm:^8.3.0"
-    "@noble/hashes": "npm:^1.3.1"
-    superstruct: "npm:^1.0.3"
-  checksum: 6d8e0727782b1c25858916c6892cd83acc7a5a26babbd0ef0f402e1af6e065a72abeb48b5cc8031eb7f3729f7d023ba80a657b0d21501033e6cfb0dc39154cd6
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-rpc-methods@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "@metamask/snaps-rpc-methods@npm:7.0.1"
+"@metamask/snaps-rpc-methods@https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-rpc-methods-7.0.1-cip3.tgz":
+  version: 7.0.1-cip3
+  resolution: "@metamask/snaps-rpc-methods@https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-rpc-methods-7.0.1-cip3.tgz"
   dependencies:
     "@metamask/key-tree": "npm:^9.0.0"
     "@metamask/permission-controller": "npm:^8.0.1"
     "@metamask/rpc-errors": "npm:^6.2.1"
-    "@metamask/snaps-sdk": "npm:^3.0.1"
-    "@metamask/snaps-utils": "npm:^7.0.1"
+    "@metamask/snaps-sdk": "workspace:^"
+    "@metamask/snaps-utils": "workspace:^"
     "@metamask/utils": "npm:^8.3.0"
     "@noble/hashes": "npm:^1.3.1"
     superstruct: "npm:^1.0.3"
-  checksum: c85359e96fd8fc69bb05d538e19434c23be2ec90ea8080ade5eac173e11997e7c78b44e0c1231eb8bb15fbbc75c55763471c139b99ba5ae999b6daf7113e8250
+  checksum: ed6b69b38e7bcad926c21330237b49f72b937e164e9369fee32f69e61a39cf36093c091f21ef87b0be5d3969b5e08ae219c69b7566f1c9f8402a5dfe74ac7a05
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@metamask/snaps-sdk@npm:3.1.0"
+"@metamask/snaps-sdk@https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-sdk-3.1.0-cip3.tgz":
+  version: 3.1.0-cip3
+  resolution: "@metamask/snaps-sdk@https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-sdk-3.1.0-cip3.tgz"
   dependencies:
     "@metamask/key-tree": "npm:^9.0.0"
     "@metamask/providers": "npm:^14.0.2"
@@ -5328,43 +5305,13 @@ __metadata:
     "@metamask/utils": "npm:^8.3.0"
     fast-xml-parser: "npm:^4.3.4"
     superstruct: "npm:^1.0.3"
-  checksum: 4ec1a9f7183302e85f41f522ce42d3084da0805ee86b3cfecefed2f3782e831a4e569e884c698449ed17772b616b7bd83a4cc45d6426ac488b6c1e5ba1f34c3c
+  checksum: b484ce212d45b8800b7dbcf5904ab009f2e63a5cd8b82b5d5f18dfe72b74274129f2a35b58ddc34de5f3d1f8598f02f4e8782ae88babe1964593d63437a1d60b
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^5.0.0, @metamask/snaps-utils@npm:^5.1.1, @metamask/snaps-utils@npm:^5.1.2, @metamask/snaps-utils@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "@metamask/snaps-utils@npm:5.2.0"
-  dependencies:
-    "@babel/core": "npm:^7.23.2"
-    "@babel/types": "npm:^7.23.0"
-    "@metamask/base-controller": "npm:^4.1.0"
-    "@metamask/key-tree": "npm:^9.0.0"
-    "@metamask/permission-controller": "npm:^7.1.0"
-    "@metamask/rpc-errors": "npm:^6.1.0"
-    "@metamask/slip44": "npm:^3.1.0"
-    "@metamask/snaps-registry": "npm:^3.0.0"
-    "@metamask/snaps-sdk": "npm:^1.4.0"
-    "@metamask/utils": "npm:^8.3.0"
-    "@noble/hashes": "npm:^1.3.1"
-    "@scure/base": "npm:^1.1.1"
-    chalk: "npm:^4.1.2"
-    cron-parser: "npm:^4.5.0"
-    fast-deep-equal: "npm:^3.1.3"
-    fast-json-stable-stringify: "npm:^2.1.0"
-    is-svg: "npm:^4.4.0"
-    rfdc: "npm:^1.3.0"
-    semver: "npm:^7.5.4"
-    ses: "npm:^1.1.0"
-    superstruct: "npm:^1.0.3"
-    validate-npm-package-name: "npm:^5.0.0"
-  checksum: bd3aa8212e7c79923769fe4102c19313ba0b55a58cc87bad3fb22e308e32faa9de80f0f36f0e3420f931115edc0b1ccac205e8a2e09247f37802b545110c48bb
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-utils@npm:^7.0.1, @metamask/snaps-utils@npm:^7.0.2":
-  version: 7.0.2
-  resolution: "@metamask/snaps-utils@npm:7.0.2"
+"@metamask/snaps-utils@https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-utils-7.0.2-cip3.tgz":
+  version: 7.0.2-cip3
+  resolution: "@metamask/snaps-utils@https://github.com/nufi-official/metamask-snaps/releases/download/v37.0.0-cip3/metamask-snaps-utils-7.0.2-cip3.tgz"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
@@ -5374,7 +5321,7 @@ __metadata:
     "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/slip44": "npm:^3.1.0"
     "@metamask/snaps-registry": "npm:^3.0.0"
-    "@metamask/snaps-sdk": "npm:^3.1.0"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/utils": "npm:^8.3.0"
     "@noble/hashes": "npm:^1.3.1"
     "@scure/base": "npm:^1.1.1"
@@ -5387,7 +5334,7 @@ __metadata:
     ses: "npm:^1.1.0"
     superstruct: "npm:^1.0.3"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: f8e98db5f8314aceb23059aac2b697ed512d1a87ba434fac7cdac1a152bff4a38a217e703c680b75b26309189d1f2145e10cc217afd7c2f4578c67f1a8e986dd
+  checksum: ed3516ce2c4773e60cca1c2e5d2eb69890cc75ce929703d58c4177636d3df39e6da275c3fdd133b75b87e13840bf8f0f9dce516bc1e0a5f59f16ef2b28f6ea0c
   languageName: node
   linkType: hard
 
@@ -5504,7 +5451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^6.0.1, @metamask/utils@npm:^6.2.0":
+"@metamask/utils@npm:^6.2.0":
   version: 6.2.0
   resolution: "@metamask/utils@npm:6.2.0"
   dependencies:
@@ -5594,13 +5541,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/ed25519@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@noble/ed25519@npm:1.6.0"
-  checksum: 11022fda81a2cbc9763aef9e4cfc2ac77136393fbacbeff54c265c70d270202d0a84b0b91c8581201b85116dc7916edb7d9123f1a583d598dc526291e6b0466c
-  languageName: node
-  linkType: hard
-
 "@noble/hashes@npm:1.1.2":
   version: 1.1.2
   resolution: "@noble/hashes@npm:1.1.2"
@@ -5615,7 +5555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.3, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:^1.3.3, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1":
+"@noble/hashes@npm:1.3.3, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:^1.3.3, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1, @noble/hashes@npm:~1.3.2":
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 1025ddde4d24630e95c0818e63d2d54ee131b980fe113312d17ed7468bc18f54486ac86c907685759f8a7e13c2f9b9e83ec7b67d1cc20836f36b5e4a65bb102d
@@ -5636,7 +5576,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:^1.5.5, @noble/secp256k1@npm:^1.7.0":
+"@noble/secp256k1@npm:^1.7.0":
   version: 1.7.1
   resolution: "@noble/secp256k1@npm:1.7.1"
   checksum: 214d4756c20ed20809d948d0cc161e95664198cb127266faf747fd7deffe5444901f05fe9f833787738f2c6e60b09e544c2f737f42f73b3699e3999ba15b1b63
@@ -6606,6 +6546,13 @@ __metadata:
   version: 1.1.3
   resolution: "@scure/base@npm:1.1.3"
   checksum: cb715fa8cdb043c4d96b6ba0666791d4eb4d033f7b5285a853aba25e0ba94914f05ff5d956029ad060005f9bdd02dab0caef9a0a63f07ed096a2c2a0c0cf9c36
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:~1.1.3":
+  version: 1.1.5
+  resolution: "@scure/base@npm:1.1.5"
+  checksum: 543fa9991c6378b6a0d5ab7f1e27b30bb9c1e860d3ac81119b4213cfdf0ad7b61be004e06506e89de7ce0cec9391c17f5c082bb34c3b617a2ee6a04129f52481
   languageName: node
   linkType: hard
 
@@ -18068,7 +18015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^4.1.3, fast-xml-parser@npm:^4.3.4":
+"fast-xml-parser@npm:^4.3.4":
   version: 4.3.4
   resolution: "fast-xml-parser@npm:4.3.4"
   dependencies:
@@ -21650,15 +21597,6 @@ __metadata:
   dependencies:
     has-tostringtag: "npm:^1.0.0"
   checksum: 2bc292fe927493fb6dfc3338c099c3efdc41f635727c6ebccf704aeb2a27bca7acb9ce6fd34d103db78692b10b22111a8891de26e12bfa1c5e11e263c99d1fef
-  languageName: node
-  linkType: hard
-
-"is-svg@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "is-svg@npm:4.4.0"
-  dependencies:
-    fast-xml-parser: "npm:^4.1.3"
-  checksum: cd5a0ba1af653e4897721913b0b80de968fa5b19eb1a592412f4672d3a1203935d183c2a9dbf61d68023739ee43d3761ea795ae1a9f618c6098a9e89eacdd256
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changes:
 - Only adding resolutions for snaps packages that needed to be changed to support `cip3` `ed25519Bip32`